### PR TITLE
Fix: Add support for autocomplete items which are snippets in Rust

### DIFF
--- a/ftplugin/rs.lua
+++ b/ftplugin/rs.lua
@@ -174,7 +174,7 @@ local function debug_test()
 	local cur_line = vim.api.nvim_win_get_cursor(0)
 	local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
 
-	local pattern = "^%s*fn%s+([%a_][%w_]*)%s*%(%s*%)%s*{"
+	local pattern = "^%s*fn%s+([%a_][%w_]*)%s*%f[%s(]"
 	local test_name = ""
 	for i = cur_line[1], 1, -1 do
 		local line = lines[i]
@@ -183,6 +183,12 @@ local function debug_test()
 			break
 		end
 	end
+
+	if test_name == nil then
+		vim.notify("Failed to find test name! Bailing!", vim.log.levels.ERROR)
+		return
+	end
+
 	local buf = vim.fn.expand("%:p:h")
 
 	vim.cmd.tabnew()

--- a/lua/logs.lua
+++ b/lua/logs.lua
@@ -336,6 +336,15 @@ M.push_log_msg = function(msg)
 end
 
 function LogMsg(msg, level, _, silent)
+	-- Workaround for Rust analyzer spam. This is a Neovim issue fixed in 10.3+
+	if string.find(msg, "-32603: Invalid offset LineCol") ~= nil then
+		return
+	end
+
+	if string.find(msg, "-32802: server cancelled the request") ~= nil then
+		return
+	end
+
 	silent = silent or false
 	local log_level = level or vim.log.levels.INFO
 

--- a/lua/lsp/snippets.lua
+++ b/lua/lsp/snippets.lua
@@ -77,6 +77,12 @@ local function on_complete_done()
 		vim.snippet.expand(snippet_text)
 		vim.api.nvim_del_autocmd(complete_done)
 		complete_done = nil
+	elseif completed_item.kind == "Keyword" then
+		vim.api.nvim_set_current_line("")
+		local snippet_text = completed_item.user_data.nvim.lsp.completion_item.textEdit.newText
+		vim.snippet.expand(snippet_text)
+		vim.api.nvim_del_autocmd(complete_done)
+		complete_done = nil
 	end
 end
 


### PR DESCRIPTION
* Some completion items of the type "Keyword" are actually snippets in Rust
* Fix Rust unit test debugging when used with parameterized rstests
* Suppress certain Rust analyzer spam which is due to Neovim's LSP implementation. This is fixed in later versions of neovim